### PR TITLE
fixed issue with optional Session cookieName

### DIFF
--- a/ios/Classes/CBManager.swift
+++ b/ios/Classes/CBManager.swift
@@ -282,23 +282,23 @@ class CBManager {
     }
     
     func inflateAuthenticator(json: Any?) throws -> Authenticator? {
-        guard let map = json as? Dictionary<String,String> else {
+        guard let map = json as? Dictionary<String,Any> else {
             return nil
         }
         
-        switch map["method"] {
+        switch map["method"] as! String {
         case "basic":
-            guard let username = map["username"], let password = map["password"] else {
+            guard let username = map["username"] as? String, let password = map["password"] as? String else {
                 throw CBManagerError.MissingArgument
             }
             
             return BasicAuthenticator(username: username, password: password)
         case "session":
-            guard let sessionId = map["sessionId"] else {
+            guard let sessionId = map["sessionId"] as? String else {
                 throw CBManagerError.MissingArgument
             }
             
-            return SessionAuthenticator(sessionID: sessionId, cookieName: map["cookieName"])
+            return SessionAuthenticator(sessionID: sessionId, cookieName: map["cookieName"] as? String)
         default:
             throw CBManagerError.IllegalArgument
         }


### PR DESCRIPTION
Fixed issue #36 (with optional cookieName in SessionAuthenticator) by loosening up the cast. 

Tested by running
-  the example app inside Xcode (to make sure that normal workflow with BasicAuthenticator was working)
- flutter test test/couchbase_lite_test.dart to see nothing was broken
- the plugin as a local pub package in an in-house application with a SessionAuthenticator
without cookieName