### PR TITLE
implemented createIndex and explainQuery

### DIFF
--- a/android/src/main/java/com/saltechsystems/couchbase_lite/QueryJson.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/QueryJson.java
@@ -274,7 +274,7 @@ class QueryJson {
         }
     }
 
-    private Expression inflateExpressionFromArray(List<Map<String, Object>> expressionParametersArray) {
+    static Expression inflateExpressionFromArray(List<Map<String, Object>> expressionParametersArray) {
         Expression returnExpression = null;
         for (int i = 0; i <= expressionParametersArray.size() - 1; i++) {
             Map<String, Object> currentExpression = expressionParametersArray.get(i);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - couchbase_lite (0.0.1):
-    - CouchbaseLite-Swift (~> 2.7.0)
+    - CouchbaseLite-Swift (~> 2.7.1)
     - Flutter
-  - CouchbaseLite-Swift (2.7.0)
+  - CouchbaseLite-Swift (2.7.1)
   - Flutter (1.0.0)
   - package_info (0.0.1):
     - Flutter
@@ -40,11 +40,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_web/ios"
 
 SPEC CHECKSUMS:
-  couchbase_lite: 1e52b370772d124e99600ffacb9adbc30383d8b4
-  CouchbaseLite-Swift: fc942af766946a7b1efbee2cc9b72ae04ec632e1
+  couchbase_lite: bb50e514b1dc8ef3a1eccd3c8e7d4d4920b7dddc
+  CouchbaseLite-Swift: 02012c1d5715106b349fb16fbcf88266d8f457c4
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  package_info: 48b108e75b8802c2d5e126f208ef540561c98aef
-  url_launcher: a1c0cc845906122c4784c542523d8cacbded5626
+  package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
+  url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
   url_launcher_macos: fd7894421cd39320dce5f292fc99ea9270b2a313
   url_launcher_web: e5527357f037c87560776e36436bf2b0288b965c
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the couchbase_lite plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.8.3 <3.0.0" 
 
 dependencies:
   # rxdart is used for the database and observable response classes

--- a/ios/Classes/QueryJson.swift
+++ b/ios/Classes/QueryJson.swift
@@ -57,7 +57,7 @@ public class QueryJson {
     private func inflateLimit() {
         let limitArray = queryMap.limit
         if (limitArray.count == 1) {
-            let limitExpression = inflateExpressionFromArray(expressionParametersArray: limitArray[0])
+            let limitExpression = QueryJson.inflateExpressionFromArray(expressionParametersArray: limitArray[0])
             switch query {
             case let _from as From:
                 query = _from.limit(limitExpression)
@@ -73,8 +73,8 @@ public class QueryJson {
                 break
             }
         } else if (limitArray.count == 2) {
-            let limitExpression = inflateExpressionFromArray(expressionParametersArray:limitArray[0])
-            let offsetExpression = inflateExpressionFromArray(expressionParametersArray:limitArray[1])
+            let limitExpression = QueryJson.self.inflateExpressionFromArray(expressionParametersArray:limitArray[0])
+            let offsetExpression = QueryJson.inflateExpressionFromArray(expressionParametersArray:limitArray[1])
             
             switch query {
             case let _from as From:
@@ -110,7 +110,7 @@ public class QueryJson {
         var groupingArray: Array<ExpressionProtocol> = []
         
         for currentGroupByExpression in groupByArray {
-            groupingArray.append(inflateExpressionFromArray(expressionParametersArray: [currentGroupByExpression]))
+            groupingArray.append(QueryJson.inflateExpressionFromArray(expressionParametersArray: [currentGroupByExpression]))
         }
         
         return groupingArray
@@ -135,7 +135,7 @@ public class QueryJson {
         var resultOrdering: Array<OrderingProtocol> = []
         
         for currentOrderByArgument in orderByArray {
-            let expression = inflateExpressionFromArray(expressionParametersArray: currentOrderByArgument)
+            let expression = QueryJson.inflateExpressionFromArray(expressionParametersArray: currentOrderByArgument)
             let ordering = Ordering.expression(expression)
             
             if let orderingSortOrder = currentOrderByArgument.last?["orderingSortOrder"] as? String  {
@@ -190,7 +190,7 @@ public class QueryJson {
             if joinsArray.count == 1 {
                 query = _from.join(joinCallback(checkedDatasource))
             } else if let joinOn = joinsArray.last?["on"] {
-                let onExpression = inflateExpressionFromArray(expressionParametersArray: QueryMap.getListOfMapFromGenericList(objectList: joinOn))
+                let onExpression = QueryJson.inflateExpressionFromArray(expressionParametersArray: QueryMap.getListOfMapFromGenericList(objectList: joinOn))
                 query = _from.join((joinCallback(checkedDatasource) as! JoinOnProtocol).on(onExpression))
             }
         }
@@ -255,7 +255,7 @@ public class QueryJson {
     }
     
     private func inflateSelectResult(selectResultParametersArray: Array<Dictionary<String, Any>> ) -> SelectResultProtocol {
-        let result = SelectResult.expression(inflateExpressionFromArray(expressionParametersArray: selectResultParametersArray))
+        let result = SelectResult.expression(QueryJson.inflateExpressionFromArray(expressionParametersArray: selectResultParametersArray))
         
         if let alias = selectResultParametersArray.last?["as"] as? String {
             return result.as(alias)
@@ -268,13 +268,13 @@ public class QueryJson {
         let whereObject = queryMap.mWhere
         
         if let _from = query as? From {
-            query = _from.where(inflateExpressionFromArray(expressionParametersArray: whereObject))
+            query = _from.where(QueryJson.inflateExpressionFromArray(expressionParametersArray: whereObject))
         } else if let _joins = query as? Joins {
-            query = _joins.where(inflateExpressionFromArray(expressionParametersArray: whereObject))
+            query = _joins.where(QueryJson.inflateExpressionFromArray(expressionParametersArray: whereObject))
         }
     }
     
-    private func inflateExpressionFromArray(expressionParametersArray: Array<Dictionary<String, Any>> ) -> ExpressionProtocol {
+    static func inflateExpressionFromArray(expressionParametersArray: Array<Dictionary<String, Any>> ) -> ExpressionProtocol {
         var returnExpression: ExpressionProtocol? = nil
         for currentExpression in expressionParametersArray {
             guard let (currentKey, currentValue) = currentExpression.first else {

--- a/lib/couchbase_lite.dart
+++ b/lib/couchbase_lite.dart
@@ -3,7 +3,7 @@ library couchbase_lite;
 import 'dart:async';
 import 'dart:collection';
 import 'dart:typed_data';
-
+import 'package:meta/meta.dart';
 import 'package:flutter/services.dart';
 import 'package:uuid/uuid.dart';
 
@@ -20,6 +20,7 @@ part 'src/listener_token.dart';
 part 'src/mutable_document.dart';
 part 'src/replicator.dart';
 part 'src/replicator_configuration.dart';
+part 'src/index.dart';
 
 part 'src/query/from.dart';
 part 'src/query/functions.dart';

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -120,12 +120,13 @@ class Database {
   /// Creates an index [withName] which could be a value index or a full-text search index.
   /// The name can be used for deleting the index. Creating a new different index with an existing index
   /// name will replace the old index; creating the same index with the same name will be no-ops.
-  /*Future<bool> createIndex(String index, {@required String withName}) async {
-    await _methodChannel.invokeMethod(
-        'deleteDocumentWithId', <String, dynamic>{'database': name, 'id': id});
-
-    return true;
-  }*/
+  Future<bool> createIndex(ValueIndex index, {@required String withName}) {
+    return _methodChannel.invokeMethod('createIndex', <String, dynamic>{
+      'database': name,
+      'index': index.toJson(),
+      'withName': withName
+    });
+  }
 
   /// Deletes index [withName] from the database.
   /*Future<void> deleteIndex({@required String withName}) async {

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -1,0 +1,41 @@
+part of couchbase_lite;
+
+class ValueIndexItem {
+  Map<String, dynamic> _map;
+
+  /// Returns the json representation of this object
+  Map<String, dynamic> toJson() => _map;
+
+  ValueIndexItem(this._map);
+
+  /// Creates a ValueIndexItem for the given [property]
+  factory ValueIndexItem.property(String property) {
+    return ValueIndexItem({'property': property});
+  }
+
+  /// Creates a ValueIndexItem for the given [expression]
+  factory ValueIndexItem.expression(Expression expression) {
+    return ValueIndexItem({'expression': expression.toJson()});
+  }
+}
+
+class ValueIndex {
+  final List<ValueIndexItem> _valueIndexItems;
+
+  ValueIndex(this._valueIndexItems);
+
+  List<Map<String, dynamic>> toJson() {
+    List<Map<String, dynamic>> map = [];
+    for (var item in _valueIndexItems) {
+      map.add(item.toJson());
+    }
+    return map;
+  }
+}
+
+class IndexBuilder {
+  /// Creates a value index with the given index items. The index items are a list of the properties or expressions to be indexed.
+  static ValueIndex valueIndex({@required List<ValueIndexItem> items}) {
+    return ValueIndex(items);
+  }
+}

--- a/lib/src/query/query.dart
+++ b/lib/src/query/query.dart
@@ -101,6 +101,24 @@ class Query {
     }
   }
 
+  /// Returns a string describing the implementation of the compiled query.
+  ///
+  /// This is intended to be read by a developer for purposes of optimizing the query,
+  /// especially to add database indexes. It’s not machine-readable and its format may change.
+  /// As currently implemented, the result is two or more lines separated by newline characters:
+  /// The first line is the SQLite SELECT statement.
+  /// The subsequent lines are the output of SQLite’s “EXPLAIN QUERY PLAN” command
+  /// applied to that statement;
+  /// for help interpreting this, see https://www.sqlite.org/eqp.html .
+  /// The most important thing to know is that if you see “SCAN TABLE”,
+  /// it means that SQLite is doing a slow linear scan of the documents instead of using an index.
+  ///
+  Future<String> explain() {
+    //Make sure the queryId is available when the toJson() method is called.
+    this._options["queryId"] = queryId;
+    return _channel.invokeMethod('explainQuery', this);
+  }
+
   Map<String, dynamic> toJson() => this.options;
 }
 


### PR DESCRIPTION
In this branch,

 I've implemented the following methods:
- Database.createIndex
- Query.explain (a handy function for developer to check if an index is used for a query)

How tested:
- A test was added into test/couchbase_lite_test.dart for index creation
- A mocked Query.explain version is added in test/couchbase_lite_test.dart
- Code was added in example/lib/data/database.dart for testing index creation and query explanation. 
- Ran unit tests to check if anything break
- Ran the modified example app on iOS and Android

Notes:
- The access of inflateExpressionFromArray method of QueryJson was changed from private to static, so that it can be used for creating index from elsewhere
- Since the operations for index creation and query explanation can be time consuming, they are executed in a separate thread for performance.


