### PR TITLE
Implemented Database.add(Document)ChangeListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.1+4
+
+* Added Database addDocumentChangeListener 
+* Added Database addChangeListener 
+* Added Database removeChangeListener
+
 ## 2.7.1+3
 
 * Setting up plugin CI/CD

--- a/android/src/main/java/com/saltechsystems/couchbase_lite/CBManager.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/CBManager.java
@@ -33,6 +33,7 @@ class CBManager {
     private HashMap<String, ListenerToken> mQueryListenerTokens = new HashMap<>();
     private HashMap<String, Replicator> mReplicators = new HashMap<>();
     private HashMap<String, ListenerToken[]> mReplicatorListenerTokens = new HashMap<>();
+    private HashMap<String, ListenerToken> mDatabaseListenerTokens = new HashMap<>();
     private DatabaseConfiguration mDBConfig;
     private CBManagerDelegate mDelegate;
 
@@ -219,10 +220,27 @@ class CBManager {
     }
 
     void closeDatabaseWithName(String _name) throws CouchbaseLiteException {
+        removeDatabaseListenerToken(_name);
         Database _db = mDatabase.remove(_name);
         if (_db != null) {
             _db.close();
         }
+    }
+
+    ListenerToken getDatabaseListenerToken(String dbname) {
+        return mDatabaseListenerTokens.get(dbname);
+    }
+
+    void addDatabaseListenerToken(String dbname, ListenerToken token) {
+        mDatabaseListenerTokens.put(dbname, token);
+    }
+
+    void removeDatabaseListenerToken(String dbname) {
+        Database _db = mDatabase.get(dbname);
+        ListenerToken token = mDatabaseListenerTokens.remove(dbname);
+        if (_db != null && token != null) {
+            _db.removeChangeListener(token);
+        } 
     }
 
     void addQuery(String queryId, Query query, ListenerToken token) {

--- a/android/src/main/java/com/saltechsystems/couchbase_lite/DatabaseEventListener.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/DatabaseEventListener.java
@@ -1,0 +1,21 @@
+package com.saltechsystems.couchbase_lite;
+
+import io.flutter.plugin.common.EventChannel;
+
+public class DatabaseEventListener implements EventChannel.StreamHandler {
+    public EventChannel.EventSink mEventSink;
+
+    /*
+     * IMPLEMENTATION OF EVENTCHANNEL.STREAMHANDLER
+     */
+
+    @Override
+    public void onListen(Object args, final EventChannel.EventSink eventSink) {
+        mEventSink = eventSink;
+    }
+
+    @Override
+    public void onCancel(Object args) {
+        mEventSink = null;
+    }
+}

--- a/ios/Classes/DatabaseEventListener.swift
+++ b/ios/Classes/DatabaseEventListener.swift
@@ -1,0 +1,25 @@
+//
+//  DatabaseEventListener.swift
+//  couchbase_lite
+//
+//  Created by Kin Mak on 8/7/2020.
+//
+
+import Foundation
+import CouchbaseLiteSwift
+
+class DatabaseEventListener: FlutterStreamHandler {
+    var mEventSink: FlutterEventSink?
+    
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        mEventSink = events
+        
+        return nil
+    }
+    
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        
+        
+        return nil
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: couchbase_lite
 description: Flutter plugin for Couchbase Lite Community Edition, an embedded lightweight, noSQL database with live synchronization and offline support on Android and iOS.
-version: 2.7.1+3
+version: 2.7.1+4
 homepage: https://github.com/SaltechSystems/couchbase_lite
 
 environment:

--- a/test/couchbase_lite_test.dart
+++ b/test/couchbase_lite_test.dart
@@ -102,6 +102,15 @@ void main() {
                 details: arguments.toString());
           }
           break;
+        case ("addDocumentChangeListener"):
+          return null;
+          break;
+        case ("addChangeListener"):
+          return null;
+          break;
+        case ("removeChangeListener"):
+          return null;
+          break;
         default:
           return UnimplementedError();
       }
@@ -185,6 +194,13 @@ void main() {
     await database.documentWithId("myid");
     // ignore: deprecated_member_use_from_same_package
     await database.save(MutableDocument());
+
+    var token = database.addChangeListener((dbChnage) => {});
+    token = await database.removeChangeListener(token);
+    expect(token, isNotNull);
+
+    token = database.addDocumentChangeListener("myid", (change) => {});
+    await database.removeChangeListener(token);
 
     var index = IndexBuilder.valueIndex(items: [
       ValueIndexItem.property("type"),


### PR DESCRIPTION
The following methods were implemented in this pull request:

- Database addDocumentChangeListener
- Database addChangeListener
- Database removeChangeListener

In addition, code was added in the example app to test the above newly added methods. Corresponding code in unit test are  also added.

Implementation details:
A new EventChannel is created and shared between the addDocumentChangeListener and addChangeListener methods in order to facilitate event streaming. 

How tested:
- Ran unit test to see if anything break
- Manually ran the (modified) example app in both iOS and Android
