### PR TITLE
Fix blob content type not parsed from queries

### DIFF
--- a/android/src/main/java/com/saltechsystems/couchbase_lite/CBManager.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/CBManager.java
@@ -124,10 +124,10 @@ class CBManager {
                 }
 
                 if (parsedMap.get("@type") instanceof String && ((String) parsedMap.get("@type")).equals("blob")) {
-                    if (parsedMap.get("data") instanceof byte[] && parsedMap.get("contentType") instanceof String) {
-                        String contentType = (String) parsedMap.get("contentType");
+                    if (parsedMap.get("data") instanceof byte[] && parsedMap.get("content_type") instanceof String) {
+                        String contentType = (String) parsedMap.get("content_type");
                         byte[] content = (byte[]) parsedMap.get("data");
-                        parsed.put(entry.getKey(), new Blob(contentType,content));
+                        parsed.put(entry.getKey(), new Blob(contentType, content));
                     } else if (originValue instanceof Blob) {
                         // Prevent blob from being deleted since the data isn't passed
                         parsed.put(entry.getKey(), originValue);
@@ -177,7 +177,7 @@ class CBManager {
             if (value instanceof Blob) {
                 Blob blob = (Blob) value;
                 HashMap<String,Object> json = new HashMap<>();
-                json.put("contentType", blob.getContentType());
+                json.put("content_type", blob.getContentType());
                 json.put("digest", blob.digest());
                 json.put("length", blob.length());
                 json.put("@type","blob");
@@ -202,6 +202,17 @@ class CBManager {
 
     Database initDatabaseWithName(String _name) throws CouchbaseLiteException {
         if (!mDatabase.containsKey(_name)) {
+            Database database = new Database(_name, mDBConfig);
+            mDatabase.put(_name, database);
+            return database;
+        }
+
+        return mDatabase.get(_name);
+    }
+
+    Database initDatabaseWithNameAndPath(String _name, String _path) throws CouchbaseLiteException {
+        if (!mDatabase.containsKey(_name)) {
+            mDBConfig.setDirectory(_path);
             Database database = new Database(_name, mDBConfig);
             mDatabase.put(_name, database);
             return database;
@@ -240,7 +251,7 @@ class CBManager {
         ListenerToken token = mDatabaseListenerTokens.remove(dbname);
         if (_db != null && token != null) {
             _db.removeChangeListener(token);
-        } 
+        }
     }
 
     void addQuery(String queryId, Query query, ListenerToken token) {

--- a/android/src/main/java/com/saltechsystems/couchbase_lite/CouchbaseLitePlugin.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/CouchbaseLitePlugin.java
@@ -174,6 +174,18 @@ public class CouchbaseLitePlugin implements CBManagerDelegate {
             result.error("errInit", "error initializing database with name " + dbname, e.toString());
           }
           break;
+        case ("initDatabaseWithNameAndPath"):
+          try {
+            final String path = call.argument("path");
+            if (path != null)
+              database = mCBManager.initDatabaseWithNameAndPath(dbname, path);
+            else
+              database = mCBManager.initDatabaseWithName(dbname);
+            result.success(database.getName());
+          } catch (Exception e) {
+            result.error("errInit", "error initializing database with name " + dbname, e.toString());
+          }
+          break;
         case ("closeDatabaseWithName"):
           if (database == null) {
             result.error("errDatabase", "Database with name " + dbname + "not found", null);
@@ -418,7 +430,7 @@ public class CouchbaseLitePlugin implements CBManagerDelegate {
               result.success(null);
           }
 
-          
+
           break;
 
         case ("removeChangeListener"):

--- a/ios/Classes/CBManager.swift
+++ b/ios/Classes/CBManager.swift
@@ -137,7 +137,7 @@ class CBManager {
             switch (value) {
             case let blob as Blob:
                 let blobJSON: [String: Any] = [
-                    "contentType": blob.contentType as Any,
+                    "content_type": blob.contentType as Any,
                     "digest": blob.digest as Any,
                     "length": blob.length,
                     "@type": "blob"

--- a/ios/Classes/DataConverter.swift
+++ b/ios/Classes/DataConverter.swift
@@ -17,8 +17,8 @@ class DataConverter {
             guard let type = result?["@type"] as? String, type == "blob" else {
                 return result
             }
-            
-            guard let contentType = result?["contentType"] as? String, let data = result?["data"] as? Data else {
+
+            guard let contentType = result?["content_type"] as? String, let data = result?["data"] as? Data else {
                 // Preserve the original blob
                 if let blob = origin as? Blob {
                     return blob

--- a/ios/Classes/SwiftCouchbaseLitePlugin.swift
+++ b/ios/Classes/SwiftCouchbaseLitePlugin.swift
@@ -79,6 +79,18 @@ public class SwiftCouchbaseLitePlugin: NSObject, FlutterPlugin, CBManagerDelegat
             } catch {
                 result(FlutterError.init(code: "errInit", message: "Error initializing database with name \(dbname)", details: error.localizedDescription))
             }
+
+        case "initDatabaseWithNameAndPath":
+            do {
+                let path = arguments["path"] as? String
+                if (path != null)
+                    let database = try mCBManager.initDatabaseWithNameAndPath(name: dbname, path: path)
+                else
+                    let database = try mCBManager.initDatabaseWithName(name: dbname)
+                result(database.name)
+            } catch {
+                result(FlutterError.init(code: "errInit", message: "Error initializing database with name \(dbname)", details: error.localizedDescription))
+            }
         case "closeDatabaseWithName":
             do {
                 try mCBManager.closeDatabaseWithName(name: dbname)

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -2,43 +2,66 @@ part of couchbase_lite;
 
 /// Couchbase Lite document. The Document is immutable.
 class Blob {
-  Blob.data(this._contentType, this._data);
+  Blob.fromData(
+    this.contentType,
+    this._data, {
+    this.dbName,
+    this.documentId,
+    this.key,
+  });
 
-  Blob._fromMap(Map<String, dynamic> map) {
-    this._contentType = map["contentType"];
-    this._digest = map["digest"];
-    this._length = map["length"];
+  Blob.fromMap(
+    Map<String, dynamic> map, {
+    this.dbName,
+    this.documentId,
+    this.key,
+  }) {
+    contentType = map["content_type"];
+    digest = map["digest"];
+    length = map["length"];
   }
 
-  String _dbname;
-  String _documentID;
-  String _documentKey;
-  String _contentType;
-  String _digest;
-  int _length;
+  @Deprecated('Use Blob.fromData instead. ')
+  Blob.data(this.contentType, this._data);
+
+  @Deprecated('Use Blob.fromMap instead. ')
+  Blob._fromMap(Map<String, dynamic> map) {
+    contentType = map["content_type"];
+    digest = map["digest"];
+    length = map["length"];
+  }
+
+  String dbName;
+  String documentId;
+  String key;
+
+  String contentType;
+  String digest;
+  int length;
   Uint8List _data;
-  bool _shouldLoadData = false;
-  String get contentType => _contentType;
-  String get digest => _digest;
-  int get length => _length;
+
   Future<Uint8List> get content async {
-    if (_shouldLoadData) {
-      return await Database._methodChannel.invokeMethod(
-          'getBlobContentFromDocumentWithId', <String, dynamic>{
-        'database': _dbname,
-        'id': _documentID,
-        'key': _documentKey,
-        'digest': _digest
-      });
-    } else {
-      return _data;
-    }
+    _data ??= await Database._methodChannel.invokeMethod(
+      'getBlobContentFromDocumentWithId',
+      <String, dynamic>{
+        'database': dbName,
+        'id': documentId,
+        'key': key,
+        'digest': digest
+      },
+    );
+
+    return _data;
   }
 
   /// Gets content of the current object as a Dictionary.
   ///
   /// - Returns: The Dictionary representing the content of the current object.
   Map<String, dynamic> toMap() {
-    return {"contentType": _contentType, "data": _data, "@type": "blob"};
+    return {
+      "content_type": contentType,
+      "data": _data,
+      "@type": "blob",
+    };
   }
 }

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -19,6 +19,14 @@ class Database {
     return Database._internal(dbName);
   }
 
+  /// Initializes a Couchbase Lite database with the given [dbName] and path.
+  static Future<Database> initWithNameAndPath(
+      String dbName, String path) async {
+    await _methodChannel.invokeMethod('initDatabaseWithNameAndPath',
+        <String, dynamic>{'database': dbName, 'path': path});
+    return Database._internal(dbName);
+  }
+
   final String name;
 
   Map<ListenerToken, StreamSubscription> tokens = {};

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -2,6 +2,18 @@ part of couchbase_lite;
 
 /// Couchbase Lite document. The Document is immutable.
 class Document {
+  Document.fromMap({
+    Map<dynamic, dynamic> data,
+    id,
+    dbname,
+    sequence,
+  }) {
+    _data = _stringMapFromDynamic(data ?? {});
+    _id = id;
+    _dbname = dbname;
+    _sequence = sequence;
+  }
+
   Document._init(
       [Map<dynamic, dynamic> data, this._id, this._dbname, this._sequence]) {
     _data = _stringMapFromDynamic(data ?? {});
@@ -14,6 +26,7 @@ class Document {
 
   String get id => _id;
   int get sequence => _sequence;
+  String get db => _dbname;
 
   Map<String, dynamic> _stringMapFromDynamic(Map<dynamic, dynamic> _map) {
     return Map.castFrom<dynamic, dynamic, String, dynamic>(_map);
@@ -95,15 +108,17 @@ class Document {
     Map<String, dynamic> _result = getMap(key);
     if (_result is Map && _result["@type"] == "blob") {
       if (_result.containsKey("data")) {
-        return Blob.data(_result["contentType"], _result["data"]);
+        return Blob.fromData(
+          _result["contentType"],
+          _result["data"],
+        );
       } else {
-        var _blob = Blob._fromMap(_result);
-        _blob._dbname = _dbname;
-        _blob._documentID = _id;
-        _blob._documentKey = key;
-        _blob._shouldLoadData = true;
-
-        return _blob;
+        return Blob.fromMap(
+          _result,
+          dbName: _dbname,
+          documentId: _id,
+          key: key,
+        );
       }
     } else {
       return null;

--- a/lib/src/query/result.dart
+++ b/lib/src/query/result.dart
@@ -1,6 +1,12 @@
 part of couchbase_lite;
 
 class Result {
+  Result();
+
+  Result.fromMap(Map<String, dynamic> map) {
+    this._internalMap = map ?? {};
+  }
+
   Map<String, dynamic> _internalMap = {};
   List<dynamic> _internalList = [];
 
@@ -33,7 +39,24 @@ class Result {
     }
   }
 
-  //TODO: implement getBlob()
+  Blob getBlob({
+    int index,
+    @required String key,
+    String dbName,
+    String documentId,
+  }) {
+    var result = getValue(index: index, key: key);
+    if (null != result) {
+      return Blob.fromMap(
+        result,
+        dbName: dbName,
+        documentId: documentId,
+        key: key,
+      );
+    } else {
+      return null;
+    }
+  }
 
   bool getBoolean({int index, String key}) {
     var result = getValue(index: index, key: key);

--- a/test/couchbase_lite_test.dart
+++ b/test/couchbase_lite_test.dart
@@ -26,6 +26,9 @@ void main() {
         case ("initDatabaseWithName"):
           return arguments["database"];
           break;
+        case ("initDatabaseWithNameAndPath"):
+          return arguments["database"];
+          break;
         case ("closeDatabaseWithName"):
           return null;
           break;
@@ -221,6 +224,12 @@ void main() {
     expect(index.toJson(), expected);
     await database.createIndex(index, withName: "MyIndex");
 
+    await database.indexes;
+    await database.compact();
+    await database.delete();
+    await Database.deleteWithName("testdb");
+
+    Database database1 = await Database.initWithNameAndPath("testdb", "/tmp");
     await database.indexes;
     await database.compact();
     await database.delete();

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -133,7 +133,7 @@ void main() {
     expect(mutableDocument.toMutable().toMap(), map);
   });
   test("Blob", () async {
-    Blob blob = Blob.data("application/octet-stream", Uint8List(0));
+    Blob blob = Blob.fromData("application/octet-stream", Uint8List(0));
     mutableDocument.setBlob("blob", blob);
     expect(await mutableDocument.getBlob("blob").content, await blob.content);
   });

--- a/test/document_test.dart
+++ b/test/document_test.dart
@@ -20,6 +20,25 @@ void main() {
     mutableDocument = MutableDocument();
   });
 
+  test("Document: fromMap", () {
+    var document = Document.fromMap(
+      data: initializer,
+      dbname: "test",
+      id: "123456789",
+      sequence: 10,
+    );
+    expect(document.id, "123456789");
+    expect(document.db, "test");
+    expect(document.sequence, 10);
+    expect(document.getString("string"), initializer['string']);
+    expect(document.getDouble("double"), initializer['double']);
+    expect(document.getInt("int"), initializer['int']);
+    expect(document.getMap("map"), {});
+    expect(document.getBoolean("bool"), initializer['bool']);
+    expect(document.getBoolean("boolint"), false);
+    expect(document.getList("list"), []);
+  });
+
   test("Document: getting string", () {
     expect(document.count(), initializer.length);
   });

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -451,7 +451,8 @@ void main() {
       "list": [],
       "double": 1.2,
       "string": "test",
-      "object": {}
+      "object": {},
+      "blob": {"content_type": "", "digest": "", "lenth": 0},
     };
     Map<dynamic, dynamic> result = {
       "map": map,
@@ -484,6 +485,10 @@ void main() {
 
     test("getInt()", () {
       expect(newResult.getInt(key: "int"), 1);
+    });
+
+    test("getBlob()", () {
+      expect(newResult.getBlob(key: "blob").runtimeType, Blob);
     });
 
     test("getKeys()", () {


### PR DESCRIPTION
- Added public contructors to the Blob class
  Makes the Blob class a bit cleaner and allows creating Blob objects from outside the library (my service classes need to be able to create blobs)

- Added Document.fromMap constructor
   with this it's possible to create proper Document objects from query results. See examples in the gist below

- Added Database.initWithNameAndPath
   just for testing at the moment

All existing code using the Document and MutableDocument should be unaffected. See examples below for normal document read and queries including joins.

https://gist.github.com/Rudiksz/cd08fb0aecab3c0a2efa534bcc03419d