### PR TITLE
Read blob files directly without calling the platform

### DIFF
--- a/android/src/main/java/com/saltechsystems/couchbase_lite/CouchbaseLitePlugin.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/CouchbaseLitePlugin.java
@@ -195,7 +195,12 @@ public class CouchbaseLitePlugin implements CBManagerDelegate {
         case ("initDatabaseWithName"):
           try {
             database = mCBManager.initDatabaseWithName(dbname);
-            result.success(database.getName());
+
+            HashMap<String,Object> config = new HashMap<>();
+            config.put("name", database.getName());
+            config.put("path", database.getPath());
+
+            result.success(config);
           } catch (Exception e) {
             result.error("errInit", "error initializing database with name " + dbname, e.toString());
           }

--- a/ios/Classes/SwiftCouchbaseLitePlugin.swift
+++ b/ios/Classes/SwiftCouchbaseLitePlugin.swift
@@ -98,7 +98,7 @@ public class SwiftCouchbaseLitePlugin: NSObject, FlutterPlugin, CBManagerDelegat
         case "initDatabaseWithName":
             do {
                 let database = try mCBManager.initDatabaseWithName(name: dbname)
-                result(database.name)
+                result(["name": database.name, "path": database.path)
             } catch {
                 result(FlutterError.init(code: "errInit", message: "Error initializing database with name \(dbname)", details: error.localizedDescription))
             }

--- a/ios/Classes/SwiftCouchbaseLitePlugin.swift
+++ b/ios/Classes/SwiftCouchbaseLitePlugin.swift
@@ -98,7 +98,7 @@ public class SwiftCouchbaseLitePlugin: NSObject, FlutterPlugin, CBManagerDelegat
         case "initDatabaseWithName":
             do {
                 let database = try mCBManager.initDatabaseWithName(name: dbname)
-                result(["name": database.name, "path": database.path)
+                result(["name": database.name, "path": database.path])
             } catch {
                 result(FlutterError.init(code: "errInit", message: "Error initializing database with name \(dbname)", details: error.localizedDescription))
             }

--- a/lib/couchbase_lite.dart
+++ b/lib/couchbase_lite.dart
@@ -1,6 +1,7 @@
 library couchbase_lite;
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:collection';
 import 'dart:typed_data';
 

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -18,6 +18,10 @@ class Blob {
   String get contentType => _contentType;
   String get digest => _digest;
   int get length => _length;
+
+  Uint8List get blobData => _data;
+  void set blobData(Uint8List data) => _data = data;
+
   Future<Uint8List> get content async {
     // Load data here if needed
     _data ??= await Database._methodChannel.invokeMethod(

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -3,7 +3,7 @@ part of couchbase_lite;
 enum ConcurrencyControl { lastWriteWins, failOnConflict }
 
 class Database {
-  Database._internal(this.name);
+  Database._internal(this.name, this.path);
 
   static const MethodChannel _methodChannel =
       MethodChannel('com.saltechsystems.couchbase_lite/database');
@@ -14,12 +14,13 @@ class Database {
 
   /// Initializes a Couchbase Lite database with the given [dbName].
   static Future<Database> initWithName(String dbName) async {
-    await _methodChannel.invokeMethod(
+    var result = await _methodChannel.invokeMethod(
         'initDatabaseWithName', <String, dynamic>{'database': dbName});
-    return Database._internal(dbName);
+    return Database._internal(dbName, result is Map ? result['path'] : null);
   }
 
   final String name;
+  final String path;
 
   Map<ListenerToken, StreamSubscription> tokens = {};
 
@@ -128,6 +129,21 @@ class Database {
     await _methodChannel.invokeMethod('clearBlobCache');
 
     return true;
+  }
+
+  Future<Uint8List> getBlobContent(Blob blob) async {
+    readContent() async {
+      var blobPath = path +
+          "Attachments/" +
+          blob.digest.replaceFirst('sha1-', '').replaceAll("/", "_") +
+          ".blob";
+
+      var file = File(blobPath);
+      return file.existsSync() ? file.readAsBytes() : null;
+    }
+
+    blob.blobData ??= await readContent();
+    return blob.blobData;
   }
 
   /// Creates an index [withName] which could be a value index or a full-text search index.


### PR DESCRIPTION
This seems to work well.
I changed the initDatabaseWithName method to return the path to avoid having to hardcode it.

I also added the "blobData" setter and getter to the Blob class to cache the result of the file operation.
The _data field clashes with the contructor name, hence the name "blobData'.

I'm using it like this atm

```
            FutureBuilder<Uint8List>(
                future: appDB.db.getBlobContent(account.avatar),
                builder: (context, snapshot) =>
                    (snapshot.hasData && snapshot.data != null)
                        ? Image(
                            width: width,
                            height: height,
                            image: MemoryImage(snapshot.data),
                          )
                        : placeholder,
              )
```

It diverges from the java and swift api, but I can live with that.