### PR TITLE
fix error when loading Blob

### DIFF
--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -4,7 +4,7 @@ part of couchbase_lite;
 class Blob {
   Blob.data(this._contentType, this._data);
 
-  Blob._fromMap(Map<String, dynamic> map) {
+  Blob._fromMap(Map<dynamic, dynamic> map) {
     _contentType = map['content_type'];
     _digest = map['digest'];
     _length = map['length'];


### PR DESCRIPTION
`Blob._fromMap` uses a typed parameter (`Map<String, dynamic>`) that doesn't match the type which is asserted in `Fragment.getValue` (a bare `Map`). This results in a runtime error of: `type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>'` when calling `document.getBlob()` in client code.