### PR TITLE
implement FullTextIndex and FullTextExpression

### DIFF
--- a/android/src/main/java/com/saltechsystems/couchbase_lite/QueryJson.java
+++ b/android/src/main/java/com/saltechsystems/couchbase_lite/QueryJson.java
@@ -3,6 +3,8 @@ package com.saltechsystems.couchbase_lite;
 import com.couchbase.lite.DataSource;
 import com.couchbase.lite.Expression;
 import com.couchbase.lite.From;
+import com.couchbase.lite.FullTextExpression;
+import com.couchbase.lite.FullTextFunction;
 import com.couchbase.lite.Function;
 import com.couchbase.lite.GroupBy;
 import com.couchbase.lite.Join;
@@ -344,6 +346,9 @@ class QueryJson {
                     case ("value"):
                         returnExpression = Expression.value(currentExpression.get("value"));
                         break;
+                    case ("rank"):
+                        returnExpression = FullTextFunction.rank((String)currentExpression.get("rank"));
+                        break;
                     case ("abs"):
                         returnExpression = Function.abs(inflateExpressionFromArray(QueryMap.getListOfMapFromGenericList(currentExpression.get("abs"))));
                         break;
@@ -454,6 +459,10 @@ class QueryJson {
                     case ("upper"):
                         returnExpression = Function.upper(inflateExpressionFromArray(QueryMap.getListOfMapFromGenericList(currentExpression.get("upper"))));
                         break;
+                    case ("fullTextMatch"):
+                        List<String> values = getStringList(currentExpression.get("fullTextMatch"));
+                        returnExpression = FullTextExpression.index(values.get(0)).match(values.get(1));
+                        break;
 
                 }
             } else {
@@ -547,6 +556,18 @@ class QueryJson {
             }
         }
         return returnExpression;
+    }
+
+    private static List<String> getStringList(Object valueList) {
+        List<String> result = new ArrayList<>();
+        if (valueList instanceof List<?>) {
+            for (Object value : (List<?>)valueList) {
+                if (value instanceof String) {
+                    result.add((String)value);
+                }
+            }
+        }
+        return result;
     }
 }
 

--- a/ios/Classes/QueryJson.swift
+++ b/ios/Classes/QueryJson.swift
@@ -450,6 +450,8 @@ public class QueryJson {
                     returnExpression = Expression.string(value)
                 case ("value", let value, _):
                     returnExpression = Expression.value(value)
+                case ("rank", let value as String, _):
+                    returnExpression = FullTextFunction.rank(value)
                 case ("abs", let value, _):
                     returnExpression = Function.abs(inflateExpressionFromArray(expressionParametersArray:
                         QueryMap.getListOfMapFromGenericList(objectList: value)))
@@ -561,7 +563,11 @@ public class QueryJson {
                 case ("upper", let value, _):
                     returnExpression = Function.upper(inflateExpressionFromArray(expressionParametersArray:
                         QueryMap.getListOfMapFromGenericList(objectList: value)))
-                    
+                case ("fullTextMatch", let value as [String], _):
+                    returnExpression =
+                        FullTextExpression
+                        .index(value[0])
+                        .match(value[1])
                 default:
                     break
                 }

--- a/lib/couchbase_lite.dart
+++ b/lib/couchbase_lite.dart
@@ -22,6 +22,7 @@ part 'src/index.dart';
 part 'src/listener_token.dart';
 part 'src/mutable_document.dart';
 part 'src/query/expression/expression.dart';
+part 'src/query/expression/full_text_expression.dart';
 part 'src/query/expression/meta.dart';
 part 'src/query/expression/meta_expression.dart';
 part 'src/query/expression/property_expression.dart';

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -133,8 +133,20 @@ class Database {
   /// Creates an index [withName] which could be a value index or a full-text search index.
   /// The name can be used for deleting the index. Creating a new different index with an existing index
   /// name will replace the old index; creating the same index with the same name will be no-ops.
-  Future<bool> createIndex(ValueIndex index, {@required String withName}) {
-    return _methodChannel.invokeMethod('createIndex', <String, dynamic>{
+  Future<bool> createIndex(Index index, {@required String withName}) {
+    var methodName;
+    if (index is ValueIndex) {
+      methodName = 'createIndex';
+    } else if (index is FullTextIndex) {
+      methodName = 'createFullTextIndex';
+    } else {
+      throw ArgumentError.value(
+        index.runtimeType,
+        'index',
+        'unknown index type',
+      );
+    }
+    return _methodChannel.invokeMethod(methodName, <String, dynamic>{
       'database': name,
       'index': index.toJson(),
       'withName': withName

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -1,5 +1,9 @@
 part of couchbase_lite;
 
+abstract class Index {
+  List<Map<String, dynamic>> toJson();
+}
+
 class ValueIndexItem {
   ValueIndexItem(this._map);
 
@@ -19,11 +23,12 @@ class ValueIndexItem {
   Map<String, dynamic> toJson() => _map;
 }
 
-class ValueIndex {
+class ValueIndex extends Index {
   ValueIndex(this._valueIndexItems);
 
   final List<ValueIndexItem> _valueIndexItems;
 
+  @override
   List<Map<String, dynamic>> toJson() {
     var map = <Map<String, dynamic>>[];
     for (var item in _valueIndexItems) {
@@ -33,9 +38,61 @@ class ValueIndex {
   }
 }
 
+class FullTextIndexItem {
+  FullTextIndexItem(this._map);
+
+  /// Creates a FullTextIndexItem for the given [property]
+  factory FullTextIndexItem.property(String property) {
+    return FullTextIndexItem({'property': property});
+  }
+
+  Map<String, dynamic> _map;
+
+  /// Returns the json representation of this object
+  Map<String, dynamic> toJson() => _map;
+}
+
+class FullTextIndex extends Index {
+  FullTextIndex(this._fullTextIndexItems);
+
+  final List<FullTextIndexItem> _fullTextIndexItems;
+  bool _ignoreAccents;
+  String _language;
+
+  FullTextIndex ignoreAccents(bool ignoreAccents) {
+    _ignoreAccents = ignoreAccents;
+    return this;
+  }
+
+  FullTextIndex language(String language) {
+    _language = language;
+    return this;
+  }
+
+  @override
+  List<Map<String, dynamic>> toJson() {
+    var map = <Map<String, dynamic>>[];
+    for (var item in _fullTextIndexItems) {
+      map.add(item.toJson());
+    }
+    if (_ignoreAccents != null) {
+      map.add({'ignoreAccents': _ignoreAccents});
+    }
+    if (_language != null) {
+      map.add({'language': _language});
+    }
+    return map;
+  }
+}
+
 class IndexBuilder {
   /// Creates a value index with the given index items. The index items are a list of the properties or expressions to be indexed.
   static ValueIndex valueIndex({@required List<ValueIndexItem> items}) {
     return ValueIndex(items);
+  }
+
+  /// Creates a full-text index with the given index items. The index items are a list of the properties to be indexed.
+  static FullTextIndex fullTextIndex({@required List<FullTextIndexItem> items}) {
+    return FullTextIndex(items);
   }
 }

--- a/lib/src/query/expression/full_text_expression.dart
+++ b/lib/src/query/expression/full_text_expression.dart
@@ -1,0 +1,39 @@
+part of couchbase_lite;
+
+class FullTextExpressionIndex {
+  final String _name;
+  FullTextExpressionIndex._(this._name);
+
+  FullTextExpression match(String query) {
+    return FullTextExpression._match(_name, query);
+  }
+}
+
+class FullTextExpression extends Object with Expression {
+  static FullTextExpressionIndex index(String name) {
+    return FullTextExpressionIndex._(name);
+  }
+
+  factory FullTextExpression.rank(String indexName) {
+    final expression = FullTextExpression._();
+    expression._internalExpressionStack.add({'rank': indexName});
+    return expression;
+  }
+
+  FullTextExpression._();
+
+ FullTextExpression._match(String indexName, String query) {
+    _internalExpressionStack.add({
+      'fullTextMatch': [indexName, query],
+    });
+ }
+
+  FullTextExpression._clone(FullTextExpression expression) {
+    _internalExpressionStack.addAll(expression.internalExpressionStack);
+  }
+
+  @override
+  FullTextExpression _clone() {
+    return FullTextExpression._clone(this);
+  }
+}


### PR DESCRIPTION
Attempted to follow Swift conventions, but uses `FullTextExpressionIndex` in place of `FullTextExpressionProtocol` because it is a more expressive name.

addresses #41