### PR TITLE
Update couchbase-lite-android to 2.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-nullsafety.2
+
+* Update Android library to version 2.8.6
+
 ## 3.0.0-nullsafety.1
 
 * Added setting logging level feature 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.0.0-nullsafety.2
 
 * Update Android library to version 2.8.6
+* Migrate the example app to null safety
+* Fix a down cast issue
 
 ## 3.0.0-nullsafety.1
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'com.couchbase.lite:couchbase-lite-android:2.8.5'
+        implementation 'com.couchbase.lite:couchbase-lite-android:2.8.6'
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: couchbase_lite
 description: Flutter plugin for Couchbase Lite Community Edition, an embedded lightweight, noSQL database with live synchronization and offline support on Android and iOS.
-version: 3.0.0-nullsafety.1
+version: 3.0.0-nullsafety.2
 homepage: https://github.com/SaltechSystems/couchbase_lite
 
 environment:


### PR DESCRIPTION
Hi,

This is a PR to update the couchbase-lite-android dependency to 2.8.6.
This version [add support for Android 11](https://docs.couchbase.com/couchbase-lite/current/android/release-notes.html) and fix [a regression introduced in the 2.8 branch of Couchbase Lite](https://issues.couchbase.com/browse/CBL-1984).

Adrien.