### PR TITLE
Fixed issue with long value in query predicate 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-nullsafety.4
+
+* Fixed issue with long value in query
+
 ## 3.0.0-nullsafety.3
 
 * Added saveDocuments and deleteDocuments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.0-nullsafety.4
 
 * Fixed issue with long value in query
+* Fixed building issue with Swift 5.5.1 compiler
 
 ## 3.0.0-nullsafety.3
 

--- a/ios/Classes/QueryJson.swift
+++ b/ios/Classes/QueryJson.swift
@@ -451,6 +451,8 @@ public class QueryJson {
                     returnExpression = Expression.float(value)
                 case ("intValue", let value as Int, _):
                     returnExpression = Expression.int(value)
+                case ("longValue", let value as Int64, _):
+                    returnExpression = Expression.int64(value)
                 case ("string", let value as String, _):
                     returnExpression = Expression.string(value)
                 case ("value", let value, _):

--- a/ios/couchbase_lite.podspec
+++ b/ios/couchbase_lite.podspec
@@ -17,7 +17,9 @@ Community edition of Couchbase Lite.  Couchbase Lite is an embedded lightweight,
   s.dependency 'Flutter'
   s.dependency 'CouchbaseLite-Swift', '~> 2.8.4'
 
-  s.ios.deployment_target = '9.0'
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target  = '10.11'
 end
 

--- a/lib/src/query/expression/expression.dart
+++ b/lib/src/query/expression/expression.dart
@@ -17,7 +17,7 @@ abstract class Expression {
   // static Expression date(DateTime value);
 
   factory Expression.intValue(int value) {
-    return VariableExpression({'intValue': value});
+    return VariableExpression({value.bitLength > 32 ? 'longValue' : 'intValue': value});
   }
 
   factory Expression.value(Object value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: couchbase_lite
 description: Flutter plugin for Couchbase Lite Community Edition, an embedded lightweight, noSQL database with live synchronization and offline support on Android and iOS.
-version: 3.0.0-nullsafety.3
+version: 3.0.0-nullsafety.4
 homepage: https://github.com/SaltechSystems/couchbase_lite
 
 environment:

--- a/test/expression_test.dart
+++ b/test/expression_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:couchbase_lite/couchbase_lite.dart';
@@ -23,6 +24,14 @@ void main() {
         {"intValue": 1452}
       ]);
     });
+    final longVal = pow(2, 50).toInt();
+    Expression longExpr = Expression.intValue(longVal);
+    test("longValue()", () {
+      expect(longExpr.toJson(), [
+        {"longValue": longVal}
+      ]);
+    });
+
     Expression negatedExpr = Expression.negated(boolExpr);
     test("negated()", () {
       expect(negatedExpr.toJson(), [


### PR DESCRIPTION
This PR fixed the issue #102 by handling the case when a query parameter is an integer whose length is > 32 bits.


Tested on both Android and iOS.